### PR TITLE
feature:#42 인터셉터를 활용한 인증토큰 공통화 처리

### DIFF
--- a/src/main/java/com/t3t/frontserver/auth/client/LogoutApiClient.java
+++ b/src/main/java/com/t3t/frontserver/auth/client/LogoutApiClient.java
@@ -1,10 +1,8 @@
 package com.t3t.frontserver.auth.client;
 
-import com.t3t.frontserver.auth.model.request.LoginRequestDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 /**
  * 로그아웃 API 호출을 위한 Feign Client

--- a/src/main/java/com/t3t/frontserver/config/FeignClientConfig.java
+++ b/src/main/java/com/t3t/frontserver/config/FeignClientConfig.java
@@ -1,10 +1,35 @@
 package com.t3t.frontserver.config;
 
+import feign.RequestInterceptor;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
+
+/**
+ * FeignClient에서 동작할 Interceptor를 정의하는 config 클래스
+ * HttpHeaders.AUTHORIZATION이 있는 경우만 requestTemplate.header에 토큰 추가
+ * @author joohyun1996(이주현)
+ */
 @Configuration
 @EnableFeignClients(basePackages = "com.t3t.frontserver")
 public class FeignClientConfig {
-
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (Objects.nonNull(attributes)) {
+                HttpServletRequest request = attributes.getRequest();
+                String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+                if (Objects.nonNull(authHeader)) {
+                    requestTemplate.header(HttpHeaders.AUTHORIZATION, authHeader);
+                }
+            }
+        };
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,5 +28,3 @@ eureka:
 t3t:
     feignClient:
         url: http://localhost:9090
-    main:
-        url: http://localhost:8080/


### PR DESCRIPTION
GlobalTokenFilter에서 HttpHeaders.AUTHORIZATION을 헤더에 포함시키면, 해당 헤더를 FeignClient에 포함시켜주는 인터셉터 구현