### PR TITLE
Feature/page admin book

### DIFF
--- a/src/main/java/com/t3t/frontserver/book/model/dto/PublisherDto.java
+++ b/src/main/java/com/t3t/frontserver/book/model/dto/PublisherDto.java
@@ -1,0 +1,17 @@
+package com.t3t.frontserver.book.model.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Getter
+@Builder
+public class PublisherDto {
+    @NotNull
+    private Long publisherId;
+    private String publisherName;
+    private String publisherEmail;
+}

--- a/src/main/java/com/t3t/frontserver/category/controller/CategoryController.java
+++ b/src/main/java/com/t3t/frontserver/category/controller/CategoryController.java
@@ -1,0 +1,25 @@
+package com.t3t.frontserver.category.controller;
+
+import com.t3t.frontserver.category.client.CategoryApiClient;
+import com.t3t.frontserver.category.response.CategoryTreeResponse;
+import com.t3t.frontserver.model.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class CategoryController {
+    private final CategoryApiClient categoryApiClient;
+
+    @GetMapping("/categories")
+    ResponseEntity<BaseResponse<List<CategoryTreeResponse>>> getCategoryTreeByDepth(@RequestParam Integer startDepth, @RequestParam Integer maxDepth) {
+        return categoryApiClient.getCategoryTreeByDepth(startDepth, maxDepth);
+    }
+}

--- a/src/main/java/com/t3t/frontserver/participant/client/ParticipantApiClient.java
+++ b/src/main/java/com/t3t/frontserver/participant/client/ParticipantApiClient.java
@@ -1,0 +1,26 @@
+package com.t3t.frontserver.participant.client;
+
+import com.t3t.frontserver.model.response.BaseResponse;
+import com.t3t.frontserver.model.response.PageResponse;
+import com.t3t.frontserver.participant.dto.ParticipantDto;
+import com.t3t.frontserver.participant.dto.ParticipantRoleDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "categoryApiClient", url = "${t3t.feignClient.url}")
+public interface ParticipantApiClient {
+
+    @GetMapping("/t3t/bookstore/participants")
+    ResponseEntity<BaseResponse<PageResponse<ParticipantDto>>> getParticipantList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "participantId", required = false) String sortBy);
+
+    @GetMapping("/t3t/bookstore/participantRoles")
+    ResponseEntity<BaseResponse<PageResponse<ParticipantRoleDto>>> getParticipantRoleList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "participantRoleId", required = false) String sortBy);
+}

--- a/src/main/java/com/t3t/frontserver/participant/controller/ParticipantController.java
+++ b/src/main/java/com/t3t/frontserver/participant/controller/ParticipantController.java
@@ -1,0 +1,38 @@
+package com.t3t.frontserver.participant.controller;
+
+import com.t3t.frontserver.model.response.BaseResponse;
+import com.t3t.frontserver.model.response.PageResponse;
+import com.t3t.frontserver.participant.client.ParticipantApiClient;
+import com.t3t.frontserver.participant.dto.ParticipantDto;
+import com.t3t.frontserver.participant.dto.ParticipantRoleDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class ParticipantController {
+    private final ParticipantApiClient participantApiClient;
+
+    @GetMapping("/participants")
+    ResponseEntity<BaseResponse<PageResponse<ParticipantDto>>> getParticipantList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "participantId", required = false) String sortBy) {
+
+        return participantApiClient.getParticipantList(pageNo, pageSize, sortBy);
+    }
+
+    @GetMapping("/participantRoles")
+    ResponseEntity<BaseResponse<PageResponse<ParticipantRoleDto>>> getParticipantRoleList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "participantRoleId", required = false) String sortBy) {
+
+        return participantApiClient.getParticipantRoleList(pageNo, pageSize, sortBy);
+    }
+}

--- a/src/main/java/com/t3t/frontserver/participant/dto/ParticipantDto.java
+++ b/src/main/java/com/t3t/frontserver/participant/dto/ParticipantDto.java
@@ -1,0 +1,21 @@
+package com.t3t.frontserver.participant.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 도서 참여자에 대한 데이터 전송 객체(DTO) <br>
+ * 각 객체는 도서 참여자의 식별자(ID)와 이름, 이메일을 가지고 있음
+ * @author Yujin-nKim(김유진)
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ParticipantDto {
+    private Long id;
+    private String name;
+    private String email;
+}

--- a/src/main/java/com/t3t/frontserver/participant/dto/ParticipantRoleDto.java
+++ b/src/main/java/com/t3t/frontserver/participant/dto/ParticipantRoleDto.java
@@ -1,0 +1,21 @@
+package com.t3t.frontserver.participant.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 도서 참여자 역할에 대한 데이터 전송 객체(DTO) <br>
+ * 각 객체는 도서 참여자 역할의 식별자(ID)와 영어 이름, 한국어 이름을 가지고 있음
+ * @author Yujin-nKim(김유진)
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ParticipantRoleDto {
+    private Integer id;
+    private String roleNameEn;
+    private String roleNameKr;
+}

--- a/src/main/java/com/t3t/frontserver/publishers/client/PublisherApiClient.java
+++ b/src/main/java/com/t3t/frontserver/publishers/client/PublisherApiClient.java
@@ -1,0 +1,18 @@
+package com.t3t.frontserver.publishers.client;
+
+import com.t3t.frontserver.book.model.dto.PublisherDto;
+import com.t3t.frontserver.model.response.BaseResponse;
+import com.t3t.frontserver.model.response.PageResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "publisherApiClient", url = "${t3t.feignClient.url}")
+public interface PublisherApiClient {
+    @GetMapping("t3t/bookstore/publishers")
+    ResponseEntity<BaseResponse<PageResponse<PublisherDto>>> getPublisherList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "publisherId", required = false) String sortBy);
+}

--- a/src/main/java/com/t3t/frontserver/publishers/controller/PublisherController.java
+++ b/src/main/java/com/t3t/frontserver/publishers/controller/PublisherController.java
@@ -1,0 +1,29 @@
+package com.t3t.frontserver.publishers.controller;
+
+import com.t3t.frontserver.book.model.dto.PublisherDto;
+import com.t3t.frontserver.model.response.BaseResponse;
+import com.t3t.frontserver.model.response.PageResponse;
+import com.t3t.frontserver.publishers.client.PublisherApiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class PublisherController {
+
+    private final PublisherApiClient publisherApiClient;
+
+    @GetMapping("/publishers")
+    public ResponseEntity<BaseResponse<PageResponse<PublisherDto>>> getPublisherList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "publisherId", required = false) String sortBy) {
+
+        return publisherApiClient.getPublisherList(pageNo, pageSize, sortBy);
+    }
+}

--- a/src/main/java/com/t3t/frontserver/tag/client/TagApiClient.java
+++ b/src/main/java/com/t3t/frontserver/tag/client/TagApiClient.java
@@ -1,0 +1,20 @@
+package com.t3t.frontserver.tag.client;
+
+import com.t3t.frontserver.book.model.dto.TagDto;
+import com.t3t.frontserver.model.response.BaseResponse;
+import com.t3t.frontserver.model.response.PageResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "tagApiClient", url = "${t3t.feignClient.url}")
+public interface TagApiClient {
+
+    @GetMapping(value = "/t3t/bookstore/tags")
+    ResponseEntity<BaseResponse<PageResponse<TagDto>>> getTagList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "tagId", required = false) String sortBy);
+
+}

--- a/src/main/java/com/t3t/frontserver/tag/controller/TagController.java
+++ b/src/main/java/com/t3t/frontserver/tag/controller/TagController.java
@@ -1,0 +1,28 @@
+package com.t3t.frontserver.tag.controller;
+
+import com.t3t.frontserver.book.model.dto.TagDto;
+import com.t3t.frontserver.model.response.BaseResponse;
+import com.t3t.frontserver.model.response.PageResponse;
+import com.t3t.frontserver.tag.client.TagApiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class TagController {
+    private final TagApiClient tagApiClient;
+
+    @GetMapping("/tags")
+    public ResponseEntity<BaseResponse<PageResponse<TagDto>>> getTagList(
+            @RequestParam(value = "pageNo", defaultValue = "0", required = false) int pageNo,
+            @RequestParam(value = "pageSize", defaultValue = "10", required = false) int pageSize,
+            @RequestParam(value = "sortBy", defaultValue = "tagId", required = false) String sortBy) {
+
+        return tagApiClient.getTagList(pageNo, pageSize, sortBy);
+    }
+}

--- a/src/main/resources/static/assets/admin/js/api.js
+++ b/src/main/resources/static/assets/admin/js/api.js
@@ -12,8 +12,7 @@ const APP_KEY = document.querySelector("#appKey").getAttribute("data-contextPath
  */
 function fetchPublishersAndUpdateModal() {
     $.ajax({
-        // url: 'http://localhost:8081/publishers',
-        url: APP_KEY + '/t3t/bookstore/publishers',
+        url : '/publishers',
         type: 'GET',
         data: {
             pageNo: currentPage,
@@ -47,8 +46,7 @@ function fetchPublishersAndUpdateModal() {
  */
 function fetchParticipantsAndUpdateModal() {
     $.ajax({
-        // url: 'http://localhost:8081/participants',
-        url: APP_KEY + '/t3t/bookstore/participants',
+        url: '/participants',
         type: 'GET',
         data: {
             pageNo: currentPage,
@@ -82,8 +80,7 @@ function fetchParticipantsAndUpdateModal() {
  */
 function fetchParticipantRolesAndUpdateModal() {
     $.ajax({
-        // url: 'http://localhost:8081/participantRoles',
-        url: APP_KEY + '/t3t/bookstore/participantRoles',
+        url: '/participantRoles',
         type: 'GET',
         data: {
             pageNo: currentPage,
@@ -116,8 +113,7 @@ function fetchParticipantRolesAndUpdateModal() {
  */
 function fetchCategoriesAndUpdateModal(startDepth, maxDepth) {
     $.ajax({
-        // url: 'http://localhost:8081/categories',
-        url: APP_KEY + '/t3t/bookstore/categories',
+        url: '/categories',
         type: 'GET',
         data: {
             startDepth: startDepth,
@@ -148,8 +144,7 @@ function fetchCategoriesAndUpdateModal(startDepth, maxDepth) {
  */
 function fetchTagsAndUpdateModal() {
     $.ajax({
-        // url: 'http://localhost:8081/tags',
-        url: APP_KEY + '/t3t/bookstore/tags',
+        url: '/tags',
         type: 'GET',
         data: {
             pageNo: currentPage,

--- a/src/main/resources/templates/main/page/detail.html
+++ b/src/main/resources/templates/main/page/detail.html
@@ -5,6 +5,12 @@
       layout:decorate="main/layout/layout">
 
 <th:block layout:fragment="content">
+
+    <!-- WYSIWYG(위즈윅) Editor css -->
+    <head>
+        <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css"/>
+    </head>
+
     <div class="container-fluid">
         <section class="py-5">
             <div class="container px-4 px-lg-5 my-5">
@@ -71,7 +77,8 @@
                             </div>
                         </div>
                         <!-- 도서 소개 -->
-                        <p class="lead" th:utext="${bookDetailList.desc}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Praesentium at dolorem quidem modi. Nam sequi consequatur obcaecati excepturi alias magni, accusamus eius blanditiis delectus ipsam minima ea iste laborum vero?</p>
+<!--                        <p class="lead" th:utext="${bookDetailList.desc}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Praesentium at dolorem quidem modi. Nam sequi consequatur obcaecati excepturi alias magni, accusamus eius blanditiis delectus ipsam minima ea iste laborum vero?</p>-->
+                        <div id="descViewer" th:value="${bookDetailList.desc}"></div>
                         <!-- 주문 option 선택 -->
                         <div th:if="${bookDetailList.orderAvailableStatus}">
                             <form th:object="${orderFormRequest}" method="post">
@@ -170,7 +177,8 @@
                                 <h2>도서 목차</h2>
                             </div>
                             <div class="col-md-8" style="padding: 30px;">
-                                <p class="lead" th:utext="${bookDetailList.index}"></p>
+<!--                                <p class="lead" th:utext="${bookDetailList.index}"></p>-->
+                                <div id="indexViewer" th:value="${bookDetailList.index}"></div>
                             </div>
                         </div>
                     </div>
@@ -217,5 +225,29 @@
             </div>
         </section>
     </div>
+    <script th:src="@{https://uicdn.toast.com/editor/latest/toastui-editor-all.min.js}"></script>
+    <script>
+        /*
+        * TOAST UI Viewer 생성 JavaScript 코드
+        */
+        var indexViewer = new toastui.Editor.factory({
+            el: document.querySelector('#indexViewer'),
+            viewer: true,
+            initialValue: document.querySelector('#indexViewer').getAttribute('value'),
+        });
+
+        var descViewer = new toastui.Editor.factory({
+            el: document.querySelector('#descViewer'),
+            viewer: true,
+            initialValue: document.querySelector('#descViewer').getAttribute('value')
+        });
+
+        // viewer 글자 크기 설정
+        var indexViewerElement = document.querySelector('#indexViewer .toastui-editor-contents');
+        indexViewerElement.style.fontSize = '20px';
+        var descViewerElement = document.querySelector('#descViewer .toastui-editor-contents');
+        descViewerElement.style.fontSize = '20px';
+
+    </script>
 </th:block>
 </html>


### PR DESCRIPTION
- 도서 상세 페이지에서 toast ui viewer 적용

- 출판사, 태그, 카테고리, 도서 참여자 및 역할 목록 조회 api 시 Front Server의 feign client를 사용해 부르도록 수정 (MIXED CONTENT 에러로 인한 수정)